### PR TITLE
fix: 회원 탈퇴 로직을 수정한다

### DIFF
--- a/src/main/java/blacktokkies/toquiz/domain/member/api/AuthApi.java
+++ b/src/main/java/blacktokkies/toquiz/domain/member/api/AuthApi.java
@@ -50,9 +50,11 @@ public class AuthApi {
     @PostMapping("api/auth/resign")
     public ResponseEntity<SuccessMessage> deleteMyInfo(
         @RequestBody @Valid ResignRequest request,
-        HttpServletResponse response
+        HttpServletResponse response,
+        @CookieValue("active_info_id") String activeInfoId,
+        @CookieValue("refresh_token") String refreshToken
         ){
-        authService.resign(request.getPassword());
+        authService.resign(request.getPassword(), activeInfoId, refreshToken);
 
         response.addCookie(cookieService.expireCookie("active_info_id"));
         response.addCookie(cookieService.expireCookie("refresh_token"));

--- a/src/main/java/blacktokkies/toquiz/domain/member/application/AuthService.java
+++ b/src/main/java/blacktokkies/toquiz/domain/member/application/AuthService.java
@@ -50,9 +50,11 @@ public class AuthService {
     }
 
     @Transactional
-    public void resign(String password){
+    public void resign(String password, String activeInfoId, String refreshToken){
         Member member = getMember();
         checkCorrectPassword(password, member.getPassword());
+        tokenService.deleteRefreshToken(member.getEmail());
+        activeInfoRepository.deleteById(activeInfoId);
         memberRepository.delete(member);
     }
 


### PR DESCRIPTION
- 로그아웃 시, 만료되는 토큰 이름 네이밍 수정
- 회원 탈퇴 시, 저장소에서 RefreshToken과 ActiveInfoId 제거 및 토큰 만료