### PR TITLE
test: Auth Service 단위 테스트를 작성한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.3.1'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.3.1'
     testImplementation 'com.google.code.gson:gson:2.10'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/blacktokkies/toquiz/domain/activeinfo/domain/ActiveInfo.java
+++ b/src/main/java/blacktokkies/toquiz/domain/activeinfo/domain/ActiveInfo.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 @Document(collection = "toquiz-member")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class ActiveInfo {
     @Id

--- a/src/main/java/blacktokkies/toquiz/domain/member/application/AuthService.java
+++ b/src/main/java/blacktokkies/toquiz/domain/member/application/AuthService.java
@@ -93,7 +93,7 @@ public class AuthService {
     }
 
     private void checkCorrectPassword(String inputPassword, String memberPassword){
-        if(!PasswordEncryptor.matchPassowrd(inputPassword, memberPassword)){
+        if(!PasswordEncryptor.matchPassword(inputPassword, memberPassword)){
             throw new RestApiException(NOT_MATCH_PASSWORD);
         }
     }

--- a/src/main/java/blacktokkies/toquiz/domain/member/application/AuthService.java
+++ b/src/main/java/blacktokkies/toquiz/domain/member/application/AuthService.java
@@ -66,11 +66,13 @@ public class AuthService {
         return AuthenticateResponse.toDto(member, accessToken);
     }
 
+    // ------------ [엔티티 가져오는 메서드] ------------ //
     private Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email)
             .orElseThrow(() -> new RestApiException(NOT_EXIST_MEMBER));
     }
 
+    // ------------ [검증 메서드] ------------ //
     private void checkExistDuplicateEmail(String email){
         if(memberRepository.existsByEmail(email)){
             throw new RestApiException(DUPLICATE_EMAIL);
@@ -95,10 +97,7 @@ public class AuthService {
         }
     }
 
-    /**
-     * 예외처리
-     * (RefreshToken이 만료 됨, 저장된 사용자의 RefreshToken과 일치하지 않음)
-     */
+     // RefreshToken이 만료 되거나 저장된 사용자의 RefreshToken과 일치하지 않으면 예외처리
     private void checkValidRefreshToken(String refreshToken, Member member){
         if(!tokenService.isTokenValid(refreshToken, member)){
             throw new RestApiException(INVALID_REFRESH_TOKEN);

--- a/src/main/java/blacktokkies/toquiz/global/util/auth/PasswordEncryptor.java
+++ b/src/main/java/blacktokkies/toquiz/global/util/auth/PasswordEncryptor.java
@@ -10,7 +10,7 @@ public class PasswordEncryptor {
         return passwordEncoder.encode(password);
     }
 
-    public static boolean matchPassowrd(String password, String encryptedPassword){
+    public static boolean matchPassword(String password, String encryptedPassword){
         return passwordEncoder.matches(password, encryptedPassword);
     }
 }

--- a/src/test/java/blacktokkies/toquiz/config/WithCustomMockUser.java
+++ b/src/test/java/blacktokkies/toquiz/config/WithCustomMockUser.java
@@ -1,0 +1,11 @@
+package blacktokkies.toquiz.config;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+}

--- a/src/test/java/blacktokkies/toquiz/config/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/blacktokkies/toquiz/config/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,33 @@
+package blacktokkies.toquiz.config;
+
+import blacktokkies.toquiz.domain.member.domain.Member;
+import blacktokkies.toquiz.domain.model.Provider;
+import blacktokkies.toquiz.global.util.auth.PasswordEncryptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation){
+        // Mock Member
+        Member member = Member.builder()
+            .email("test311@naver.com")
+            .password(PasswordEncryptor.encryptPassword("test@311"))
+            .nickname("TEST")
+            .provider(Provider.LOCAL)
+            .activeInfoId("{activeInfoId}")
+            .build();
+
+        final SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        final Authentication auth = new UsernamePasswordAuthenticationToken(member, member.getPassword(),
+            member.getAuthorities());
+
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}

--- a/src/test/java/blacktokkies/toquiz/member/api/MemberApiTest.java
+++ b/src/test/java/blacktokkies/toquiz/member/api/MemberApiTest.java
@@ -136,66 +136,6 @@ public class MemberApiTest {
         }
         @Nested
         class 자신의_사용자_정보_수정하기_실패{
-            @Nested
-            class 형식_제약_검증_실패 {
-                @Test
-                void 닉네임_길이_제약_검증() throws Exception {
-                    // given
-                    final UpdateMyInfoRequest request1 = UpdateMyInfoRequest.builder() // 길이가 2자 미만
-                        .password("test@311")
-                        .nickname("T")
-                        .build();
-
-                    final UpdateMyInfoRequest request2 = UpdateMyInfoRequest.builder() // 길이가 20자 초과
-                        .password("test@311")
-                        .nickname("TEST01234567890123456789")
-                        .build();
-
-                    // when
-                    final ResultActions resultActions1 = requestApi(request1);
-                    final ResultActions resultActions2 = requestApi(request2);
-
-                    // then
-                    resultActions1.andExpect(status().isBadRequest()).andReturn();
-                    resultActions2.andExpect(status().isBadRequest()).andReturn();
-                }
-
-                @Test
-                void 비밀번호_형식_제약_검증() throws Exception {
-                    // given
-                    final UpdateMyInfoRequest request = UpdateMyInfoRequest.builder()
-                        .password("test11311")
-                        .nickname("TEST")
-                        .build();
-
-                    // when
-                    final ResultActions resultActions = requestApi(request);
-
-                    // then
-                    resultActions.andExpect(status().isBadRequest()).andReturn();
-                }
-
-                @Test
-                void 비밀번호_길이_제약_검증() throws Exception {
-                    final UpdateMyInfoRequest request1 = UpdateMyInfoRequest.builder() // 길이가 8자 미만
-                        .password("test@12")
-                        .nickname("TEST")
-                        .build();
-
-                    final UpdateMyInfoRequest request2 = UpdateMyInfoRequest.builder() // 길이가 20자 초과
-                        .password("test@012345678012345678")
-                        .nickname("TEST")
-                        .build();
-
-                    // when
-                    ResultActions resultActions1 = requestApi(request1);
-                    ResultActions resultActions2 = requestApi(request2);
-
-                    // then
-                    resultActions1.andExpect(status().isBadRequest()).andReturn();
-                    resultActions2.andExpect(status().isBadRequest()).andReturn();
-                }
-            }
             @Test
             void 유효하지_않은_액세스_토큰(){
                 // given

--- a/src/test/java/blacktokkies/toquiz/member/application/AuthServiceTest.java
+++ b/src/test/java/blacktokkies/toquiz/member/application/AuthServiceTest.java
@@ -1,0 +1,21 @@
+package blacktokkies.toquiz.member.application;
+
+import blacktokkies.toquiz.domain.activeinfo.ActiveInfoRepository;
+import blacktokkies.toquiz.domain.member.application.AuthService;
+import blacktokkies.toquiz.domain.member.dao.MemberRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+    @InjectMocks // 가짜 객체 생성
+    private AuthService authService;
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private ActiveInfoRepository activeInfoRepository;
+
+}

--- a/src/test/java/blacktokkies/toquiz/member/application/AuthServiceTest.java
+++ b/src/test/java/blacktokkies/toquiz/member/application/AuthServiceTest.java
@@ -1,21 +1,192 @@
 package blacktokkies.toquiz.member.application;
 
 import blacktokkies.toquiz.domain.activeinfo.ActiveInfoRepository;
+import blacktokkies.toquiz.domain.activeinfo.domain.ActiveInfo;
+import blacktokkies.toquiz.domain.activeinfo.domain.ActivePanel;
 import blacktokkies.toquiz.domain.member.application.AuthService;
 import blacktokkies.toquiz.domain.member.dao.MemberRepository;
+import blacktokkies.toquiz.domain.member.domain.Member;
+import blacktokkies.toquiz.domain.member.dto.request.LoginRequest;
+import blacktokkies.toquiz.domain.member.dto.request.SignUpRequest;
+import blacktokkies.toquiz.domain.member.dto.response.AuthenticateResponse;
+import blacktokkies.toquiz.domain.model.Provider;
+import blacktokkies.toquiz.global.config.SecurityConfig;
+import blacktokkies.toquiz.global.util.auth.TokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ContextConfiguration;
 
-@ExtendWith(MockitoExtension.class)
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({MockitoExtension.class})
+@ContextConfiguration(classes = SecurityConfig.class)
 public class AuthServiceTest {
-    @InjectMocks // 가짜 객체 생성
+    @InjectMocks
     private AuthService authService;
 
     @Mock
     private MemberRepository memberRepository;
     @Mock
     private ActiveInfoRepository activeInfoRepository;
+    @Mock
+    private TokenService tokenService;
 
+    @Spy
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void init(){
+        passwordEncoder = new BCryptPasswordEncoder();
+    }
+
+    @Test
+    @DisplayName("회원 가입")
+    void signUp(){
+        // given
+        final SignUpRequest request = SignUpRequest.builder()
+            .email("test311@naver.com")
+            .password("test@311")
+            .nickname("TEST")
+            .build();
+        final ActiveInfo activeInfo = ActiveInfo.builder()
+            .id("5d3f30de25874467999fc7325f6539ba07d62a0b")
+            .activePanels(new HashMap<String, ActivePanel>())
+            .build();
+        Member member = request.toMemberWith(activeInfo);
+
+        doReturn(activeInfo).when(activeInfoRepository).save(any(ActiveInfo.class));
+        doReturn(member).when(memberRepository).save(any(Member.class));
+
+        // when
+        authService.signUp(request);
+
+        // verify
+        verify(memberRepository, times(1)).save(any(Member.class));
+        verify(activeInfoRepository, times(1)).save(any(ActiveInfo.class));
+    }
+
+    @DisplayName("로그인")
+    @Test
+    void login(){
+        // given
+        passwordEncoder = new BCryptPasswordEncoder();
+
+        final String newAccessToken = "{NewAccessToken}";
+
+        LoginRequest request = LoginRequest.builder()
+            .email("test311@naver.com")
+            .password("test@311")
+            .build();
+
+        Optional<Member> optionalMember = Optional.ofNullable(Member.builder()
+            .email("test311@naver.com")
+            .password(passwordEncoder.encode("test@311"))
+            .provider(Provider.LOCAL)
+            .nickname("TEST")
+            .build());
+
+        doReturn(newAccessToken).when(tokenService).generateAccessToken(any(String.class));
+        doReturn(optionalMember).when(memberRepository).findByEmail(any(String.class));
+
+        // when
+        AuthenticateResponse result = authService.login(request);
+
+        // then
+        assertThat(result.getEmail()).isEqualTo(request.getEmail());
+        assertThat(result.getAccessToken()).isEqualTo(newAccessToken);
+
+        // verify
+        verify(tokenService, times(1)).generateAccessToken(any(String.class));
+    }
+
+    @Test
+    @DisplayName("로그아웃")
+    void logout(){
+        // given
+        final Member member = Member.builder()
+            .email("test311@naver.com")
+            .password(passwordEncoder.encode("test@311"))
+            .provider(Provider.LOCAL)
+            .nickname("TEST")
+            .build();
+
+        doNothing().when(tokenService).deleteRefreshToken(any(String.class));
+
+        // when
+        authService.logout(member);
+
+        // verify
+        verify(tokenService, times(1)).deleteRefreshToken(any(String.class));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴")
+    void resign(){
+        passwordEncoder = new BCryptPasswordEncoder();
+        // given
+        final Member member = Member.builder()
+            .email("test311@naver.com")
+            .password(passwordEncoder.encode("test@311"))
+            .provider(Provider.LOCAL)
+            .nickname("TEST")
+            .activeInfoId("a1c2t3i4v5e6I7n8f9oId")
+            .build();
+        final String inputPassword = "test@311";
+        final String activeInfoId = "{ActiveInfoId}";
+
+        doNothing().when(tokenService).deleteRefreshToken(any(String.class));
+        doNothing().when(activeInfoRepository).deleteById(any(String.class));
+        doNothing().when(memberRepository).delete(any(Member.class));
+
+        // when
+        authService.resign(member, inputPassword, activeInfoId);
+
+        // then
+        verify(tokenService, times(1)).deleteRefreshToken(any(String.class));
+        verify(activeInfoRepository, times(1)).deleteById(any(String.class));
+        verify(memberRepository, times(1)).delete(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 갱신")
+    void refresh(){
+        // given
+        final String refreshToken = "{RefreshToken}";
+        final String newAccessToken = "{NewAccessToken}";
+        final Member member = Member.builder()
+            .email("test311@naver.com")
+            .password(passwordEncoder.encode("test@311"))
+            .provider(Provider.LOCAL)
+            .nickname("TEST")
+            .activeInfoId("a1c2t3i4v5e6I7n8f9oId")
+            .build();
+
+        doReturn(true).when(tokenService).isTokenValid(any(String.class), any(Member.class));
+        doNothing().when(tokenService).validateRefreshToken(any(String.class), any(String.class));
+        doReturn(newAccessToken).when(tokenService).generateAccessToken(any(String.class));
+
+        // when
+        AuthenticateResponse result = authService.refresh(member, refreshToken);
+
+        // then
+        assertThat(result.getEmail()).isEqualTo(member.getEmail());
+        assertThat(result.getAccessToken()).isEqualTo(newAccessToken);
+
+        verify(tokenService, times(1)).isTokenValid(any(String.class), any(Member.class));
+        verify(tokenService, times(1)).validateRefreshToken(any(String.class), any(String.class));
+        verify(tokenService, times(1)).generateAccessToken(any(String.class));
+    }
 }


### PR DESCRIPTION
- #82 
- AuthApi에서 Member를 받아, AuthService에 전달하도록 수정
  - 수정 전: AuthService에서 `SecurityContextHolder.getContext().getAuthentication().getPrincipal()`를 통해 받아옴
  - 수정 후: AuthApi에서 `@AuthenticationPrincipal`을 통해 받아오고 이를 AuthService에 전달
- AuthService의 `refresh` 로직 수정