### PR TITLE
test: Member Service 단위 테스트를 작성한다

### DIFF
--- a/src/main/java/blacktokkies/toquiz/domain/member/api/MemberApi.java
+++ b/src/main/java/blacktokkies/toquiz/domain/member/api/MemberApi.java
@@ -1,13 +1,14 @@
 package blacktokkies.toquiz.domain.member.api;
 
 import blacktokkies.toquiz.domain.member.application.MemberService;
+import blacktokkies.toquiz.domain.member.domain.Member;
 import blacktokkies.toquiz.domain.member.dto.request.UpdateMyInfoRequest;
 import blacktokkies.toquiz.domain.member.dto.response.MemberInfoResponse;
-import blacktokkies.toquiz.global.common.response.SuccessMessage;
 import blacktokkies.toquiz.global.common.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,17 +17,20 @@ public class MemberApi {
     private final MemberService memberService;
 
     @GetMapping("api/members/me")
-    public ResponseEntity<SuccessResponse<MemberInfoResponse>> getMyInfo(){
-        MemberInfoResponse response = memberService.getMyInfo();
+    public ResponseEntity<SuccessResponse<MemberInfoResponse>> getMyInfo(
+        @AuthenticationPrincipal Member member
+    ){
+        MemberInfoResponse response = memberService.getMyInfo(member);
 
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 
     @PatchMapping("api/members/me")
     public ResponseEntity<SuccessResponse<MemberInfoResponse>> updateMyInfo(
+        @AuthenticationPrincipal Member member,
         @RequestBody @Valid UpdateMyInfoRequest request
         ){
-        MemberInfoResponse response = memberService.updateMyInfo(request);
+        MemberInfoResponse response = memberService.updateMyInfo(member, request);
 
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }

--- a/src/main/java/blacktokkies/toquiz/domain/member/application/MemberService.java
+++ b/src/main/java/blacktokkies/toquiz/domain/member/application/MemberService.java
@@ -17,13 +17,12 @@ import static blacktokkies.toquiz.domain.member.exception.MemberErrorCode.DUPLIC
 @Transactional(readOnly = true)
 public class MemberService {
     private final MemberRepository memberRepository;
-    public MemberInfoResponse getMyInfo() {
-        return MemberInfoResponse.toDto(getMember());
+    public MemberInfoResponse getMyInfo(Member member) {
+        return MemberInfoResponse.toDto(member);
     }
 
     @Transactional
-    public MemberInfoResponse updateMyInfo(UpdateMyInfoRequest updateMyInfoRequest) {
-        Member member = getMember();
+    public MemberInfoResponse updateMyInfo(Member member, UpdateMyInfoRequest updateMyInfoRequest) {
         updateNickName(member, updateMyInfoRequest.getNickname());
         updatePassword(member, updateMyInfoRequest.getPassword());
         Member updatedMember = memberRepository.save(member);
@@ -45,9 +44,5 @@ public class MemberService {
         if(newPassword == null) return;
 
         member.updatePassword(newPassword);
-    }
-
-    private Member getMember(){
-        return (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     }
 }

--- a/src/test/java/blacktokkies/toquiz/member/api/MemberApiTest.java
+++ b/src/test/java/blacktokkies/toquiz/member/api/MemberApiTest.java
@@ -1,7 +1,9 @@
 package blacktokkies.toquiz.member.api;
 
+import blacktokkies.toquiz.config.WithCustomMockUser;
 import blacktokkies.toquiz.domain.member.api.MemberApi;
 import blacktokkies.toquiz.domain.member.application.MemberService;
+import blacktokkies.toquiz.domain.member.domain.Member;
 import blacktokkies.toquiz.domain.member.dto.request.UpdateMyInfoRequest;
 import blacktokkies.toquiz.domain.member.dto.response.MemberInfoResponse;
 import blacktokkies.toquiz.domain.model.Provider;
@@ -51,6 +53,7 @@ public class MemberApiTest {
     }
 
     @Nested
+    @WithCustomMockUser
     @DisplayName("자신의 사용자 정보 가져오기")
     class GetMyInfo{
         private ResultActions requestApi() throws Exception {
@@ -73,7 +76,7 @@ public class MemberApiTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-            doReturn(response).when(memberService).getMyInfo();
+            doReturn(response).when(memberService).getMyInfo(any(Member.class));
 
             // when
             final ResultActions resultActions = requestApi();
@@ -89,7 +92,7 @@ public class MemberApiTest {
             @Test
             void 유효하지_않은_액세스_토큰(){
                 // given
-                doThrow(new RestApiException(INVALID_ACCESS_TOKEN)).when(memberService).getMyInfo();
+                doThrow(new RestApiException(INVALID_ACCESS_TOKEN)).when(memberService).getMyInfo(any(Member.class));
 
                 // when, then
                 assertThatThrownBy(() -> requestApi()).hasCause(new RestApiException(INVALID_ACCESS_TOKEN));
@@ -124,7 +127,7 @@ public class MemberApiTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-            doReturn(response).when(memberService).updateMyInfo(any(UpdateMyInfoRequest.class));
+            doReturn(response).when(memberService).updateMyInfo(any(Member.class), any(UpdateMyInfoRequest.class));
 
             // when
             final ResultActions resultActions = requestApi(request);
@@ -144,7 +147,7 @@ public class MemberApiTest {
                     .nickname("modify")
                     .build();
 
-                doThrow(new RestApiException(INVALID_ACCESS_TOKEN)).when(memberService).updateMyInfo(any(UpdateMyInfoRequest.class));
+                doThrow(new RestApiException(INVALID_ACCESS_TOKEN)).when(memberService).updateMyInfo(any(Member.class), any(UpdateMyInfoRequest.class));
 
                 // when, then
                 assertThatThrownBy(() -> requestApi(request)).hasCause(new RestApiException(INVALID_ACCESS_TOKEN));

--- a/src/test/java/blacktokkies/toquiz/member/application/AuthServiceTest.java
+++ b/src/test/java/blacktokkies/toquiz/member/application/AuthServiceTest.java
@@ -32,7 +32,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith({MockitoExtension.class})
-@ContextConfiguration(classes = SecurityConfig.class)
 public class AuthServiceTest {
     @InjectMocks
     private AuthService authService;

--- a/src/test/java/blacktokkies/toquiz/member/application/MemberServiceTest.java
+++ b/src/test/java/blacktokkies/toquiz/member/application/MemberServiceTest.java
@@ -1,0 +1,63 @@
+package blacktokkies.toquiz.member.application;
+
+import blacktokkies.toquiz.domain.member.application.MemberService;
+import blacktokkies.toquiz.domain.member.dao.MemberRepository;
+import blacktokkies.toquiz.domain.member.domain.Member;
+import blacktokkies.toquiz.domain.member.dto.request.UpdateMyInfoRequest;
+import blacktokkies.toquiz.domain.member.dto.response.MemberInfoResponse;
+import blacktokkies.toquiz.domain.model.Provider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({MockitoExtension.class})
+public class MemberServiceTest {
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("자신의 사용자 정보 가져오기")
+    void getMyInfo(){}
+
+    @Test
+    @DisplayName("자신의 사용자 정보 수정하기")
+    void updateMyInfo(){
+        // given
+        final String updatePassword = "update@311";
+        final String updateNickname = "update";
+        final UpdateMyInfoRequest updateMyInfoRequest = UpdateMyInfoRequest.builder()
+            .password(updatePassword)
+            .nickname(updateNickname)
+            .build();
+        final Member member = Member.builder()
+            .email("test311@naver.com")
+            .password("test@311")
+            .provider(Provider.LOCAL)
+            .nickname("TEST")
+            .activeInfoId("a1c2t3i4v5e6I7n8f9oId")
+            .build();
+
+        doReturn(false).when(memberRepository).existsByNickname(any(String.class));
+        doReturn(member).when(memberRepository).save(any(Member.class));
+
+        // when
+        MemberInfoResponse result = memberService.updateMyInfo(member, updateMyInfoRequest);
+
+        // then
+        assertThat(result.getEmail()).isEqualTo(member.getEmail());
+        assertThat(result.getNickname()).isEqualTo(updateNickname);
+
+        verify(memberRepository, times(1)).existsByNickname(any(String.class));
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+}


### PR DESCRIPTION
- #82 
- MemberApi에서 Member를 받아, MemberService에 전달하도록 수정
  - 수정 전: MemberService에서 `SecurityContextHolder.getContext().getAuthentication().getPrincipal()`를 통해 받아옴
  - 수정 후: MemberApi에서 `@AuthenticationPrincipal`을 통해 받아오고 이를 MemberService에 전달